### PR TITLE
Correctly decode emoji data as UTF-8

### DIFF
--- a/lib/src/emoji.dart
+++ b/lib/src/emoji.dart
@@ -81,7 +81,7 @@ Future<List<EmojiDefinition>> getEmojiDefinitions() async {
     return _cachedEmojiDefinitions!;
   } else {
     final response = await http.get(_emojiDefinitionsUrl);
-    final data = jsonDecode(response.body)['emojiDefinitions'];
+    final data = jsonDecode(utf8.decode(response.bodyBytes))['emojiDefinitions'];
 
     _cachedAt = DateTime.timestamp();
     return _cachedEmojiDefinitions = [

--- a/test/integration/emoji_test.dart
+++ b/test/integration/emoji_test.dart
@@ -7,4 +7,10 @@ void main() {
 
     expect(emojis, isNotEmpty);
   });
+
+  test('getEmojiDefinitions correcly decodes emojis', () async {
+    final emoji = (await getEmojiDefinitions()).singleWhere((element) => element.primaryName == 'heart');
+
+    expect(emoji.surrogates, equals('❤️'));
+  });
 }


### PR DESCRIPTION
# Description

Using `response.body` from `package:http` was causing the emoji data to be decoded as `latin-1` (as the response does not specify what encoding it is using). The response is actually UTF-8 encoded and this causes issue when parsing the emojis themselves.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
