### PR TITLE
Don't add controls to paginated messages multiple times

### DIFF
--- a/lib/src/pagination.dart
+++ b/lib/src/pagination.dart
@@ -432,6 +432,12 @@ class _PaginationState {
       throw NyxxException('Cannot add pagination controls to builder: too many component rows');
     }
 
+    final knownIds = {jumpToStartId, jumpToEndId, previousId, nextId};
+    if (builder.components?.any((row) => row.components.any((element) => element is ButtonBuilder && knownIds.contains(element.customId))) == true) {
+      // We've already added controls to this builder, likely when the user navigated to this page previously.
+      return;
+    }
+
     final showJumpToEnds = options?.showJumpToEnds ?? pagination.options.showJumpToEnds ?? true;
     final showPageIndex = options?.showPageIndex ?? pagination.options.showPageIndex ?? true;
 


### PR DESCRIPTION
# Description

As the title says. Currently navigating backwards to a page already seen attempts to add the controls to that page again, which causes an error.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
