### PR TITLE
Add methods for computing permissions in a channel.

### DIFF
--- a/lib/nyxx_extensions.dart
+++ b/lib/nyxx_extensions.dart
@@ -11,3 +11,4 @@ export 'src/role.dart';
 export 'src/sanitizer.dart';
 export 'src/user.dart';
 export 'src/utils/formatters.dart';
+export 'src/permissions.dart';

--- a/lib/src/permissions.dart
+++ b/lib/src/permissions.dart
@@ -1,0 +1,95 @@
+import 'package:nyxx/nyxx.dart';
+
+/// Compute the permissions for [member] in a given [channel].
+///
+/// {@template compute_permissions_detail}
+/// This method returns the permissions for [member] according to the
+/// permissions granted to them by their roles at a guild level as well as
+/// the permission overwrites for [channel].
+///
+/// Adapted from https://discord.com/developers/docs/topics/permissions#permission-overwrites
+/// {@endtemplate}
+Future<Permissions> computePermissions(
+  GuildChannel channel,
+  Member member,
+) async {
+  final guild = await channel.guild.get();
+
+  Future<Permissions> computeBasePermissions() async {
+    if (guild.ownerId == member.id) {
+      return Permissions.allPermissions;
+    }
+
+    final everyoneRole = await guild.roles[guild.id].get();
+    Flags<Permissions> permissions = everyoneRole.permissions;
+
+    for (final role in member.roles) {
+      final rolePermissions = (await role.get()).permissions;
+
+      permissions |= rolePermissions;
+    }
+
+    permissions = Permissions(permissions.value);
+    permissions as Permissions;
+
+    if (permissions.isAdministrator) {
+      return Permissions.allPermissions;
+    }
+
+    return permissions;
+  }
+
+  Future<Permissions> computeOverwrites(Permissions basePermissions) async {
+    if (basePermissions.isAdministrator) {
+      return Permissions.allPermissions;
+    }
+
+    Flags<Permissions> permissions = basePermissions;
+
+    final everyoneOverwrite = channel.permissionOverwrites.where((overwrite) => overwrite.id == guild.id).singleOrNull;
+    if (everyoneOverwrite != null) {
+      permissions &= ~everyoneOverwrite.deny;
+      permissions |= everyoneOverwrite.allow;
+    }
+
+    Flags<Permissions> allow = Permissions(0);
+    Flags<Permissions> deny = Permissions(0);
+
+    for (final roleId in member.roleIds) {
+      final roleOverwrite = channel.permissionOverwrites.where((overwrite) => overwrite.id == roleId).singleOrNull;
+      if (roleOverwrite != null) {
+        allow |= roleOverwrite.allow;
+        deny |= roleOverwrite.deny;
+      }
+    }
+
+    permissions &= ~deny;
+    permissions |= allow;
+
+    final memberOverwrite = channel.permissionOverwrites.where((overwrite) => overwrite.id == member.id).singleOrNull;
+    if (memberOverwrite != null) {
+      permissions &= ~memberOverwrite.deny;
+      permissions |= memberOverwrite.allow;
+    }
+
+    return Permissions(permissions.value);
+  }
+
+  return computeOverwrites(await computeBasePermissions());
+}
+
+/// Extensions for computing permissions in a [GuildChannel].
+extension MemberComputePermissions on PartialMember {
+  /// Compute this member's permissions in [channel].
+  ///
+  /// {@macro compute_permissions_detail}
+  Future<Permissions> computePermissionsIn(GuildChannel channel) async => await computePermissions(channel, await get());
+}
+
+/// Extensions for computing a [Member]'s permissions.
+extension ChannelComputePermissions on GuildChannel {
+  /// Compute [member]'s permissions in this channel.
+  ///
+  /// {@macro compute_permissions_detail}
+  Future<Permissions> computePermissionsFor(PartialMember member) async => await computePermissions(this, await member.get());
+}


### PR DESCRIPTION
# Description

This PR exposes the `computePermissions` utility method already present in `nyxx_commands`, as it may be useful for other developers.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
