### PR TITLE
Add endpoint pagination for reactions

### DIFF
--- a/lib/src/extensions/managers/message_manager.dart
+++ b/lib/src/extensions/managers/message_manager.dart
@@ -34,4 +34,23 @@ extension MessageManagerExtensions on MessageManager {
         pageSize: pageSize,
         order: order,
       );
+
+  /// Same as [fetchReactions], but has no limit on the number of reactions returned.
+  ///
+  /// {@macro paginated_endpoint_streaming_parameters}
+  Stream<User> streamReactions(
+    Snowflake id,
+    ReactionBuilder emoji, {
+    Snowflake? after,
+    Snowflake? before,
+    int? pageSize,
+  }) =>
+      streamPaginatedEndpoint(
+        ({before, after, limit}) => fetchReactions(id, emoji, after: after, limit: limit),
+        extractId: (user) => user.id,
+        before: before,
+        after: after,
+        pageSize: pageSize,
+        order: StreamOrder.oldestFirst,
+      );
 }

--- a/lib/src/extensions/message.dart
+++ b/lib/src/extensions/message.dart
@@ -1,5 +1,6 @@
 import 'package:nyxx/nyxx.dart';
 import 'package:nyxx_extensions/src/extensions/channel.dart';
+import 'package:nyxx_extensions/src/utils/endpoint_paginator.dart';
 
 /// Extensions on [Message]s.
 extension MessageExtensions on Message {
@@ -25,4 +26,22 @@ extension MessageExtensions on Message {
 
     return channel.sendMessage(copiedBuilder);
   }
+
+  /// Same as [fetchReactions], but has no limit on the number of reactions returned.
+  ///
+  /// {@macro paginated_endpoint_streaming_parameters}
+  Stream<User> streamReactions(
+    ReactionBuilder emoji, {
+    Snowflake? after,
+    Snowflake? before,
+    int? pageSize,
+  }) =>
+      streamPaginatedEndpoint(
+        ({before, after, limit}) => manager.fetchReactions(id, emoji, after: after, limit: limit),
+        extractId: (user) => user.id,
+        before: before,
+        after: after,
+        pageSize: pageSize,
+        order: StreamOrder.oldestFirst,
+      );
 }

--- a/lib/src/extensions/message.dart
+++ b/lib/src/extensions/message.dart
@@ -1,6 +1,5 @@
 import 'package:nyxx/nyxx.dart';
-import 'package:nyxx_extensions/src/extensions/channel.dart';
-import 'package:nyxx_extensions/src/utils/endpoint_paginator.dart';
+import 'package:nyxx_extensions/nyxx_extensions.dart';
 
 /// Extensions on [Message]s.
 extension MessageExtensions on Message {
@@ -36,12 +35,5 @@ extension MessageExtensions on Message {
     Snowflake? before,
     int? pageSize,
   }) =>
-      streamPaginatedEndpoint(
-        ({before, after, limit}) => manager.fetchReactions(id, emoji, after: after, limit: limit),
-        extractId: (user) => user.id,
-        before: before,
-        after: after,
-        pageSize: pageSize,
-        order: StreamOrder.oldestFirst,
-      );
+      manager.streamReactions(id, emoji, after: after, before: before, pageSize: pageSize);
 }

--- a/lib/src/utils/formatters.dart
+++ b/lib/src/utils/formatters.dart
@@ -1,4 +1,4 @@
-import 'package:nyxx/src/models/snowflake.dart';
+import 'package:nyxx/nyxx.dart';
 
 /// Wraps the [code] in a code block with the specified language, if any.
 String codeBlock(String code, [String language = '']) => '```$language\n$code\n```';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^1.1.0
-  nyxx: ^6.0.0
+  nyxx: ^6.2.0
 
 dev_dependencies:
   coverage: ^1.0.3


### PR DESCRIPTION
# Description

Adds pagination for `MessageManager.fetchReactions`, which wasn't previously possible as pre-6.2.0 nyxx didn't include the pagination parameters for this endpoint.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
