### PR TITLE
Add getter for everyone role in a guild

### DIFF
--- a/lib/src/extensions/managers/role_manager.dart
+++ b/lib/src/extensions/managers/role_manager.dart
@@ -1,0 +1,6 @@
+import 'package:nyxx/nyxx.dart';
+
+extension RoleManagerExtensions on RoleManager {
+  /// The role representing `@everyone` in this guild.
+  PartialRole get everyone => this[guildId];
+}


### PR DESCRIPTION
# Description

Adds a getter for the `@everyone` role in a guild, represented by the role with the same ID as the guild.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
