### PR TITLE
Add extension getter for cdn assets

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -24,7 +24,7 @@ void main() async {
   // Sanitizing content makes it safe to send to Discord without triggering any mentions
   client.onMessageCreate.listen((event) async {
     if (event.message.content.startsWith('!sanitize')) {
-      event.message.channel.sendMessage(MessageBuilder(
+      await event.message.channel.sendMessage(MessageBuilder(
         content: 'Sanitized content: ${await sanitizeContent(event.message.content, channel: event.message.channel)}',
       ));
     }
@@ -63,6 +63,16 @@ ullamcorper morbi tincidunt ornare.
         loreumIpsum,
         // Split into chunks 100 characters long.
         maxLength: 100,
+      ));
+    }
+  });
+
+  client.onMessageCreate.listen((event) async {
+    if (event.message.content.startsWith('!avatar') && event.message.mentions.isNotEmpty) {
+      // Display the first mentioned user's avatar with the specified size.
+      final user = event.message.mentions.first;
+      await event.message.channel.sendMessage(MessageBuilder(
+        content: 'Avatar URL: ${user.avatar.get(format: CdnFormat.jpeg, size: 3072)}',
       ));
     }
   });

--- a/lib/nyxx_extensions.dart
+++ b/lib/nyxx_extensions.dart
@@ -9,6 +9,7 @@ export 'src/utils/pagination.dart';
 export 'src/utils/permissions.dart';
 export 'src/utils/sanitizer.dart';
 
+export 'src/extensions/cdn_asset.dart' hide getRequest;
 export 'src/extensions/channel.dart';
 export 'src/extensions/client.dart';
 export 'src/extensions/date_time.dart';

--- a/lib/src/extensions/cdn_asset.dart
+++ b/lib/src/extensions/cdn_asset.dart
@@ -1,0 +1,22 @@
+import 'package:nyxx/nyxx.dart';
+
+extension CdnAssetExtensions on CdnAsset {
+  Uri get({CdnFormat? format, int? size}) => getRequest(this, format ?? defaultFormat, size).prepare(client).url;
+}
+
+// Re-implementing the private method from CdnAsset
+CdnRequest getRequest(CdnAsset asset, CdnFormat format, int? size) {
+  final route = HttpRoute();
+
+  for (final part in asset.base.parts) {
+    route.add(part);
+  }
+  route.add(HttpRoutePart('${asset.hash}.${format.extension}'));
+
+  return CdnRequest(
+    route,
+    queryParameters: {
+      if (size != null) 'size': size.toString(),
+    },
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^1.1.0
-  nyxx: ^6.2.1
+  nyxx: ^6.3.0
 
 dev_dependencies:
   coverage: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^1.1.0
-  nyxx: ^6.0.0
+  nyxx: ^6.2.1
 
 dev_dependencies:
   coverage: ^1.0.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   http: ^1.1.0
-  nyxx: ^6.3.0
+  nyxx: ^6.3.1
 
 dev_dependencies:
   coverage: ^1.0.3

--- a/test/integration/member_test.dart
+++ b/test/integration/member_test.dart
@@ -27,4 +27,15 @@ void main() {
       expect(mutualGuilds, isNotEmpty);
     },
   );
+
+  test('avatar.get()', skip: testToken == null ? 'No token provided' : false, () async {
+    final client = await Nyxx.connectRest(testToken!);
+
+    final self = await client.users.fetchCurrentUser();
+
+    expect(
+      self.avatar.get(size: 3072, format: CdnFormat.jpeg),
+      Uri.https('cdn.discordapp.com', 'avatars/${self.id}/${self.avatarHash}.${CdnFormat.jpeg.extension}', {'size': '3072'}),
+    );
+  });
 }

--- a/test/unit/timestamp_style_test.dart
+++ b/test/unit/timestamp_style_test.dart
@@ -6,37 +6,13 @@ final baseDate = Snowflake(846136758470443069).timestamp;
 
 void main() {
   group('Timestamp Test', () {
-    test(
-        'None',
-        () => expect(baseDate.format(),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}>')));
-    test(
-        'Short Time',
-        () => expect(baseDate.format(TimestampStyle.shortTime),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:t>')));
-    test(
-        'Long Time',
-        () => expect(baseDate.format(TimestampStyle.longTime),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:T>')));
-    test(
-        'Short Date',
-        () => expect(baseDate.format(TimestampStyle.shortDate),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:d>')));
-    test(
-        'Long Date',
-        () => expect(baseDate.format(TimestampStyle.longDate),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:D>')));
-    test(
-        'Short Date Time',
-        () => expect(baseDate.format(TimestampStyle.shortDateTime),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:f>')));
-    test(
-        'Long Date Time',
-        () => expect(baseDate.format(TimestampStyle.longDateTime),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:F>')));
-    test(
-        'Relative Time',
-        () => expect(baseDate.format(TimestampStyle.relativeTime),
-            equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:R>')));
+    test('None', () => expect(baseDate.format(), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}>')));
+    test('Short Time', () => expect(baseDate.format(TimestampStyle.shortTime), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:t>')));
+    test('Long Time', () => expect(baseDate.format(TimestampStyle.longTime), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:T>')));
+    test('Short Date', () => expect(baseDate.format(TimestampStyle.shortDate), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:d>')));
+    test('Long Date', () => expect(baseDate.format(TimestampStyle.longDate), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:D>')));
+    test('Short Date Time', () => expect(baseDate.format(TimestampStyle.shortDateTime), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:f>')));
+    test('Long Date Time', () => expect(baseDate.format(TimestampStyle.longDateTime), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:F>')));
+    test('Relative Time', () => expect(baseDate.format(TimestampStyle.relativeTime), equals('<t:${baseDate.millisecondsSinceEpoch ~/ 1000}:R>')));
   });
 }


### PR DESCRIPTION
# Description

Add a way to get the url of the asset without fetching it.

Test are failing because the CI bot doesnt have an avatar, and `CdnRequest` from nyxx doesn't forward qzery paramters .

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
