### PR TITLE
Added .toBuilder() method to GuildChannel

### DIFF
--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -22,10 +22,11 @@ extension GuildChannelExtensions on GuildChannel {
   ///
   /// {@macro compute_permissions_detail}
   Future<Permissions> computePermissionsFor(PartialMember member) async => await computePermissions(this, await member.get());
+}
 
-  /// Create a builder with the properties of this channel
-  // TODO: Which gegeric type should be provided here?
-  CreateBuilder<GuildChannel> toBuilder() {
+/// Extensions on all [GuildChannel] types
+extension GuildChannelsExtension<T extends GuildChannel> on T {
+  CreateBuilder<T> toBuilder() {
     switch (type) {
       case ChannelType.guildText:
         var cast = this as GuildTextChannel;
@@ -38,7 +39,7 @@ extension GuildChannelExtensions on GuildChannel {
           parentId: parentId,
           rateLimitPerUser: cast.rateLimitPerUser,
           topic: cast.topic,
-        );
+        ) as CreateBuilder<T>;
       case ChannelType.privateThread:
         var cast = this as PrivateThread;
         return ThreadBuilder.privateThread(
@@ -46,20 +47,20 @@ extension GuildChannelExtensions on GuildChannel {
           autoArchiveDuration: cast.autoArchiveDuration,
           invitable: cast.isInvitable,
           rateLimitPerUser: cast.rateLimitPerUser,
-        );
+        ) as CreateBuilder<T>;
       case ChannelType.publicThread:
         var cast = this as PublicThread;
         return ThreadBuilder.publicThread(
           name: name,
           autoArchiveDuration: cast.autoArchiveDuration,
           rateLimitPerUser: cast.rateLimitPerUser,
-        );
+        ) as CreateBuilder<T>;
       case ChannelType.guildCategory:
         return GuildCategoryBuilder(
           name: name,
           permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
           position: position,
-        );
+        ) as CreateBuilder<T>;
       case ChannelType.guildVoice:
         var cast = this as GuildVoiceChannel;
         return GuildVoiceChannelBuilder(
@@ -72,7 +73,7 @@ extension GuildChannelExtensions on GuildChannel {
           rtcRegion: cast.rtcRegion,
           userLimit: cast.userLimit,
           videoQualityMode: cast.videoQualityMode,
-        );
+        ) as CreateBuilder<T>;
       case ChannelType.guildAnnouncement:
         var cast = this as GuildAnnouncementChannel;
         return GuildAnnouncementChannelBuilder(
@@ -83,7 +84,7 @@ extension GuildChannelExtensions on GuildChannel {
           permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
           position: position,
           topic: cast.topic,
-        );
+        ) as CreateBuilder<T>;
       case ChannelType.guildStageVoice:
         var cast = this as GuildStageChannel;
         return GuildStageChannelBuilder(
@@ -96,7 +97,7 @@ extension GuildChannelExtensions on GuildChannel {
           rtcRegion: cast.rtcRegion,
           userLimit: cast.userLimit,
           videoQualityMode: cast.videoQualityMode,
-        );
+        ) as CreateBuilder<T>;
       default:
         return GuildChannelBuilder(
           name: name,

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -26,87 +26,83 @@ extension GuildChannelExtensions on GuildChannel {
 
 /// Extensions on all [GuildChannel] types
 extension GuildChannelsExtension<T extends GuildChannel> on T {
-  CreateBuilder<T> toBuilder() {
-    switch (type) {
-      case ChannelType.guildText:
-        var cast = this as GuildTextChannel;
-        return GuildTextChannelBuilder(
-          name: name,
-          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-          position: position,
-          defaultAutoArchiveDuration: cast.defaultAutoArchiveDuration,
-          isNsfw: isNsfw,
-          parentId: parentId,
-          rateLimitPerUser: cast.rateLimitPerUser,
-          topic: cast.topic,
-        ) as CreateBuilder<T>;
-      case ChannelType.privateThread:
-        var cast = this as PrivateThread;
-        return ThreadBuilder.privateThread(
-          name: name,
-          autoArchiveDuration: cast.autoArchiveDuration,
-          invitable: cast.isInvitable,
-          rateLimitPerUser: cast.rateLimitPerUser,
-        ) as CreateBuilder<T>;
-      case ChannelType.publicThread:
-        var cast = this as PublicThread;
-        return ThreadBuilder.publicThread(
-          name: name,
-          autoArchiveDuration: cast.autoArchiveDuration,
-          rateLimitPerUser: cast.rateLimitPerUser,
-        ) as CreateBuilder<T>;
-      case ChannelType.guildCategory:
-        return GuildCategoryBuilder(
-          name: name,
-          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-          position: position,
-        ) as CreateBuilder<T>;
-      case ChannelType.guildVoice:
-        var cast = this as GuildVoiceChannel;
-        return GuildVoiceChannelBuilder(
-          name: name,
-          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-          position: position,
-          isNsfw: isNsfw,
-          parentId: parentId,
-          bitRate: cast.bitrate,
-          rtcRegion: cast.rtcRegion,
-          userLimit: cast.userLimit,
-          videoQualityMode: cast.videoQualityMode,
-        ) as CreateBuilder<T>;
-      case ChannelType.guildAnnouncement:
-        var cast = this as GuildAnnouncementChannel;
-        return GuildAnnouncementChannelBuilder(
-          name: name,
-          defaultAutoArchiveDuration: cast.defaultAutoArchiveDuration,
-          isNsfw: isNsfw,
-          parentId: parentId,
-          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-          position: position,
-          topic: cast.topic,
-        ) as CreateBuilder<T>;
-      case ChannelType.guildStageVoice:
-        var cast = this as GuildStageChannel;
-        return GuildStageChannelBuilder(
-          name: name,
-          bitRate: cast.bitrate,
-          isNsfw: isNsfw,
-          parentId: parentId,
-          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-          position: position,
-          rtcRegion: cast.rtcRegion,
-          userLimit: cast.userLimit,
-          videoQualityMode: cast.videoQualityMode,
-        ) as CreateBuilder<T>;
-      default:
-        return GuildChannelBuilder(
-          name: name,
-          type: type,
-          position: position,
-          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-        );
-    }
-  }
+  /// Create a builder with the properties of this channel
+  GuildChannelBuilder<T> toBuilder() => switch (this) {
+        GuildTextChannel channel => GuildTextChannelBuilder(
+            name: channel.name,
+            defaultAutoArchiveDuration: channel.defaultAutoArchiveDuration,
+            isNsfw: channel.isNsfw,
+            parentId: channel.parentId,
+            permissionOverwrites: channel.permissionOverwrites
+                .map((e) => PermissionOverwriteBuilder(
+                      id: e.id,
+                      type: e.type,
+                      allow: e.allow,
+                      deny: e.deny,
+                    ))
+                .toList(),
+            position: channel.position,
+            rateLimitPerUser: channel.rateLimitPerUser,
+            topic: channel.topic,
+          ) as GuildChannelBuilder<T>,
+        GuildVoiceChannel channel => GuildVoiceChannelBuilder(
+            name: channel.name,
+            permissionOverwrites:
+                channel.permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+            position: channel.position,
+            isNsfw: channel.isNsfw,
+            parentId: channel.parentId,
+            bitRate: channel.bitrate,
+            rtcRegion: channel.rtcRegion,
+            userLimit: channel.userLimit,
+            videoQualityMode: channel.videoQualityMode,
+          ) as GuildChannelBuilder<T>,
+        GuildStageChannel channel => GuildStageChannelBuilder(
+            name: channel.name,
+            bitRate: channel.bitrate,
+            isNsfw: channel.isNsfw,
+            parentId: channel.parentId,
+            permissionOverwrites:
+                channel.permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+            position: channel.position,
+            rtcRegion: channel.rtcRegion,
+            userLimit: channel.userLimit,
+            videoQualityMode: channel.videoQualityMode,
+          ) as GuildChannelBuilder<T>,
+        PrivateThread thread => ThreadBuilder.privateThread(
+            name: thread.name,
+            autoArchiveDuration: thread.autoArchiveDuration,
+            invitable: thread.isInvitable,
+            rateLimitPerUser: thread.rateLimitPerUser,
+          ) as GuildChannelBuilder<T>,
+        PublicThread thread => ThreadBuilder.publicThread(
+            name: thread.name,
+            autoArchiveDuration: thread.autoArchiveDuration,
+            rateLimitPerUser: thread.rateLimitPerUser,
+          ) as GuildChannelBuilder<T>,
+        GuildCategory category => GuildCategoryBuilder(
+            name: category.name,
+            permissionOverwrites:
+                category.permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+            position: category.position,
+          ) as GuildChannelBuilder<T>,
+        GuildAnnouncementChannel channel => GuildAnnouncementChannelBuilder(
+            name: channel.name,
+            defaultAutoArchiveDuration: channel.defaultAutoArchiveDuration,
+            isNsfw: channel.isNsfw,
+            parentId: channel.parentId,
+            permissionOverwrites:
+                channel.permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+            position: channel.position,
+            topic: channel.topic,
+          ) as GuildChannelBuilder<T>,
+        _ => GuildChannelBuilder(
+            name: name,
+            type: type,
+            position: position,
+            permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+          ),
+      };
 }
 
 /// Extensions on [Thread]s.

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -22,6 +22,12 @@ extension GuildChannelExtensions on GuildChannel {
   ///
   /// {@macro compute_permissions_detail}
   Future<Permissions> computePermissionsFor(PartialMember member) async => await computePermissions(this, await member.get());
+
+  /// Create a builder with the properties of this channel
+  GuildChannelBuilder toBuilder() => GuildChannelBuilder(
+      name: name,
+      type: type,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList());
 }
 
 /// Extensions on [Thread]s.

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -29,6 +29,7 @@ extension GuildChannelExtensions on GuildChannel {
   GuildChannelBuilder toBuilder() => GuildChannelBuilder(
         name: name,
         type: type,
+        position: position,
         permissionOverwrites: permissionOverwrites
             .map((e) => PermissionOverwriteBuilder(
                   id: e.id,
@@ -56,13 +57,21 @@ extension ThreadExtensions on Thread {
           before: before,
           pageSize: pageSize);
 
-  /// Create a builder with the properties of this thread
-  ThreadBuilder toBuilder() => ThreadBuilder(
-        name: name,
-        type: type,
-        autoArchiveDuration: autoArchiveDuration,
-        rateLimitPerUser: rateLimitPerUser,
-      );
+  /// Create a builder with the properties of this thread.
+  ThreadBuilder toBuilder() {
+    // Check for PrivateThread to pass invitable to the builder
+    bool? invitable;
+    if (this is PrivateThread) {
+      invitable = (this as PrivateThread).isInvitable;
+    }
+    return ThreadBuilder(
+      name: name,
+      type: type,
+      autoArchiveDuration: autoArchiveDuration,
+      invitable: invitable,
+      rateLimitPerUser: rateLimitPerUser,
+    );
+  }
 }
 
 /// Extensions on [GuildCategory]s.
@@ -78,7 +87,7 @@ extension GuildCategoryExtensions on GuildCategory {
   List<GuildChannel> get cachedChannels =>
       guild.cachedChannels.where((element) => element.parentId == id).toList();
 
-  /// Create a builder with the properties of this category
+  /// Create a builder with the properties of this category.
   GuildCategoryBuilder toBuilder() => GuildCategoryBuilder(
         name: name,
         permissionOverwrites: permissionOverwrites
@@ -91,7 +100,7 @@ extension GuildCategoryExtensions on GuildCategory {
 
 /// Extensions on [GuildTextChannel]s.
 extension GuildTextChannelExtensions on GuildTextChannel {
-  /// Create a builder with the properties of this channel
+  /// Create a builder with the properties of this channel.
   GuildTextChannelBuilder toBuilder() => GuildTextChannelBuilder(
         name: name,
         permissionOverwrites: permissionOverwrites
@@ -109,7 +118,7 @@ extension GuildTextChannelExtensions on GuildTextChannel {
 
 /// Extensions on [GuildVoiceChannel]s.
 extension GuildVoiceChannelExtensions on GuildVoiceChannel {
-  /// Create a builder with the properties of this channel
+  /// Create a builder with the properties of this channel.
   GuildVoiceChannelBuilder toBuilder() => GuildVoiceChannelBuilder(
         name: name,
         permissionOverwrites: permissionOverwrites
@@ -128,7 +137,7 @@ extension GuildVoiceChannelExtensions on GuildVoiceChannel {
 
 /// Extensions on [GuildAnnouncementChannel]s.
 extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
-  /// Create a builder with the properties of this channel
+  /// Create a builder with the properties of this channel.
   GuildAnnouncementChannelBuilder toBuilder() =>
       GuildAnnouncementChannelBuilder(
         name: name,
@@ -146,7 +155,7 @@ extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
 
 /// Extensions on [GuildStageChannel]s.
 extension GuildStageChannelExtensions on GuildStageChannel {
-  /// Create a builder with the properties of this channel
+  /// Create a builder with the properties of this channel.
   GuildStageChannelBuilder toBuilder() => GuildStageChannelBuilder(
         name: name,
         bitRate: bitrate,

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -37,6 +37,9 @@ extension ThreadExtensions on Thread {
   /// {@macro paginated_endpoint_streaming_parameters}
   Stream<ThreadMember> streamThreadMembers({bool? withMembers, Snowflake? after, Snowflake? before, int? pageSize}) =>
       manager.streamThreadMembers(id, withMembers: withMembers, after: after, before: before, pageSize: pageSize);
+
+  /// Create a builder with the properties of this thread
+  ThreadBuilder toBuilder() => ThreadBuilder(name: name, type: type, autoArchiveDuration: autoArchiveDuration, rateLimitPerUser: rateLimitPerUser);
 }
 
 /// Extensions on [GuildCategory]s.
@@ -50,4 +53,66 @@ extension GuildCategoryExtensions on GuildCategory {
 
   /// Return a list of channels in the client's cache that are in this category.
   List<GuildChannel> get cachedChannels => guild.cachedChannels.where((element) => element.parentId == id).toList();
+
+  /// Create a builder with the properties of this category
+  GuildCategoryBuilder toBuilder() => GuildCategoryBuilder(
+      name: name,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+      position: position);
+}
+
+/// Extensions on [GuildTextChannel]s.
+extension GuildTextChannelExtensions on GuildTextChannel {
+  /// Create a builder with the properties of this channel
+  GuildTextChannelBuilder toBuilder() => GuildTextChannelBuilder(
+      name: name,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+      position: position,
+      defaultAutoArchiveDuration: defaultAutoArchiveDuration,
+      isNsfw: isNsfw,
+      parentId: parentId,
+      rateLimitPerUser: rateLimitPerUser,
+      topic: topic);
+}
+
+/// Extensions on [GuildVoiceChannel]s.
+extension GuildVoiceChannelExtensions on GuildVoiceChannel {
+  /// Create a builder with the properties of this channel
+  GuildVoiceChannelBuilder toBuilder() => GuildVoiceChannelBuilder(
+      name: name,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+      position: position,
+      isNsfw: isNsfw,
+      parentId: parentId,
+      bitRate: bitrate,
+      rtcRegion: rtcRegion,
+      userLimit: userLimit,
+      videoQualityMode: videoQualityMode);
+}
+
+/// Extensions on [GuildAnnouncementChannel]s.
+extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
+  /// Create a builder with the properties of this channel
+  GuildAnnouncementChannelBuilder toBuilder() => GuildAnnouncementChannelBuilder(
+      name: name,
+      defaultAutoArchiveDuration: defaultAutoArchiveDuration,
+      isNsfw: isNsfw,
+      parentId: parentId,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+      position: position,
+      topic: topic);
+}
+
+extension Test on GuildStageChannel {
+  /// Create a builder with the properties of this channel
+  GuildStageChannelBuilder toBuilder() => GuildStageChannelBuilder(
+      name: name,
+      bitRate: bitrate,
+      isNsfw: isNsfw,
+      parentId: parentId,
+      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+      position: position,
+      rtcRegion: rtcRegion,
+      userLimit: userLimit,
+      videoQualityMode: videoQualityMode);
 }

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -24,12 +24,88 @@ extension GuildChannelExtensions on GuildChannel {
   Future<Permissions> computePermissionsFor(PartialMember member) async => await computePermissions(this, await member.get());
 
   /// Create a builder with the properties of this channel
-  GuildChannelBuilder toBuilder() => GuildChannelBuilder(
-        name: name,
-        type: type,
-        position: position,
-        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-      );
+  // TODO: Which gegeric type should be provided here?
+  CreateBuilder<GuildChannel> toBuilder() {
+    switch (type) {
+      case ChannelType.guildText:
+        var cast = this as GuildTextChannel;
+        return GuildTextChannelBuilder(
+          name: name,
+          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+          position: position,
+          defaultAutoArchiveDuration: cast.defaultAutoArchiveDuration,
+          isNsfw: isNsfw,
+          parentId: parentId,
+          rateLimitPerUser: cast.rateLimitPerUser,
+          topic: cast.topic,
+        );
+      case ChannelType.privateThread:
+        var cast = this as PrivateThread;
+        return ThreadBuilder.privateThread(
+          name: name,
+          autoArchiveDuration: cast.autoArchiveDuration,
+          invitable: cast.isInvitable,
+          rateLimitPerUser: cast.rateLimitPerUser,
+        );
+      case ChannelType.publicThread:
+        var cast = this as PublicThread;
+        return ThreadBuilder.publicThread(
+          name: name,
+          autoArchiveDuration: cast.autoArchiveDuration,
+          rateLimitPerUser: cast.rateLimitPerUser,
+        );
+      case ChannelType.guildCategory:
+        return GuildCategoryBuilder(
+          name: name,
+          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+          position: position,
+        );
+      case ChannelType.guildVoice:
+        var cast = this as GuildVoiceChannel;
+        return GuildVoiceChannelBuilder(
+          name: name,
+          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+          position: position,
+          isNsfw: isNsfw,
+          parentId: parentId,
+          bitRate: cast.bitrate,
+          rtcRegion: cast.rtcRegion,
+          userLimit: cast.userLimit,
+          videoQualityMode: cast.videoQualityMode,
+        );
+      case ChannelType.guildAnnouncement:
+        var cast = this as GuildAnnouncementChannel;
+        return GuildAnnouncementChannelBuilder(
+          name: name,
+          defaultAutoArchiveDuration: cast.defaultAutoArchiveDuration,
+          isNsfw: isNsfw,
+          parentId: parentId,
+          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+          position: position,
+          topic: cast.topic,
+        );
+      case ChannelType.guildStageVoice:
+        var cast = this as GuildStageChannel;
+        return GuildStageChannelBuilder(
+          name: name,
+          bitRate: cast.bitrate,
+          isNsfw: isNsfw,
+          parentId: parentId,
+          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+          position: position,
+          rtcRegion: cast.rtcRegion,
+          userLimit: cast.userLimit,
+          videoQualityMode: cast.videoQualityMode,
+        );
+      default:
+        return GuildChannelBuilder(
+          name: name,
+          type: type,
+          position: position,
+          permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
+        );
+    }
+  }
 }
 
 /// Extensions on [Thread]s.
@@ -39,15 +115,6 @@ extension ThreadExtensions on Thread {
   /// {@macro paginated_endpoint_streaming_parameters}
   Stream<ThreadMember> streamThreadMembers({bool? withMembers, Snowflake? after, Snowflake? before, int? pageSize}) =>
       manager.streamThreadMembers(id, withMembers: withMembers, after: after, before: before, pageSize: pageSize);
-
-  /// Create a builder with the properties of this thread.
-  ThreadBuilder toBuilder() => ThreadBuilder(
-        name: name,
-        type: type,
-        autoArchiveDuration: autoArchiveDuration,
-        invitable: this is PrivateThread ? (this as PrivateThread).isInvitable : null,
-        rateLimitPerUser: rateLimitPerUser,
-      );
 }
 
 /// Extensions on [GuildCategory]s.
@@ -61,72 +128,4 @@ extension GuildCategoryExtensions on GuildCategory {
 
   /// Return a list of channels in the client's cache that are in this category.
   List<GuildChannel> get cachedChannels => guild.cachedChannels.where((element) => element.parentId == id).toList();
-
-  /// Create a builder with the properties of this category.
-  GuildCategoryBuilder toBuilder() => GuildCategoryBuilder(
-        name: name,
-        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-        position: position,
-      );
-}
-
-/// Extensions on [GuildTextChannel]s.
-extension GuildTextChannelExtensions on GuildTextChannel {
-  /// Create a builder with the properties of this channel.
-  GuildTextChannelBuilder toBuilder() => GuildTextChannelBuilder(
-        name: name,
-        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-        position: position,
-        defaultAutoArchiveDuration: defaultAutoArchiveDuration,
-        isNsfw: isNsfw,
-        parentId: parentId,
-        rateLimitPerUser: rateLimitPerUser,
-        topic: topic,
-      );
-}
-
-/// Extensions on [GuildVoiceChannel]s.
-extension GuildVoiceChannelExtensions on GuildVoiceChannel {
-  /// Create a builder with the properties of this channel.
-  GuildVoiceChannelBuilder toBuilder() => GuildVoiceChannelBuilder(
-        name: name,
-        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-        position: position,
-        isNsfw: isNsfw,
-        parentId: parentId,
-        bitRate: bitrate,
-        rtcRegion: rtcRegion,
-        userLimit: userLimit,
-        videoQualityMode: videoQualityMode,
-      );
-}
-
-/// Extensions on [GuildAnnouncementChannel]s.
-extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
-  /// Create a builder with the properties of this channel.
-  GuildAnnouncementChannelBuilder toBuilder() => GuildAnnouncementChannelBuilder(
-        name: name,
-        defaultAutoArchiveDuration: defaultAutoArchiveDuration,
-        isNsfw: isNsfw,
-        parentId: parentId,
-        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-        position: position,
-        topic: topic,
-      );
-}
-
-/// Extensions on [GuildStageChannel]s.
-extension GuildStageChannelExtensions on GuildStageChannel {
-  /// Create a builder with the properties of this channel.
-  GuildStageChannelBuilder toBuilder() => GuildStageChannelBuilder(
-        name: name,
-        bitRate: bitrate,
-        isNsfw: isNsfw,
-        parentId: parentId,
-        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-        position: position,
-        rtcRegion: rtcRegion,
-        userLimit: userLimit,
-        videoQualityMode: videoQualityMode,
-      );
 }

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -13,7 +13,8 @@ extension PartialChannelExtensions on PartialChannel {
 /// Extensions on [Channel]s.
 extension ChannelExtensions on Channel {
   /// A URL clients can visit to navigate to this channel.
-  Uri get url => Uri.https(manager.client.apiOptions.host, '/channels/${this is GuildChannel ? '${(this as GuildChannel).guildId}' : '@me'}/$id');
+  Uri get url => Uri.https(manager.client.apiOptions.host,
+      '/channels/${this is GuildChannel ? '${(this as GuildChannel).guildId}' : '@me'}/$id');
 }
 
 /// Extensions on [GuildChannel]s.
@@ -21,13 +22,22 @@ extension GuildChannelExtensions on GuildChannel {
   /// Compute [member]'s permissions in this channel.
   ///
   /// {@macro compute_permissions_detail}
-  Future<Permissions> computePermissionsFor(PartialMember member) async => await computePermissions(this, await member.get());
+  Future<Permissions> computePermissionsFor(PartialMember member) async =>
+      await computePermissions(this, await member.get());
 
   /// Create a builder with the properties of this channel
   GuildChannelBuilder toBuilder() => GuildChannelBuilder(
-      name: name,
-      type: type,
-      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList());
+        name: name,
+        type: type,
+        permissionOverwrites: permissionOverwrites
+            .map((e) => PermissionOverwriteBuilder(
+                  id: e.id,
+                  type: e.type,
+                  allow: e.allow,
+                  deny: e.deny,
+                ))
+            .toList(),
+      );
 }
 
 /// Extensions on [Thread]s.
@@ -35,11 +45,24 @@ extension ThreadExtensions on Thread {
   /// Same as [listThreadMembers], but has no limit on the number of members returned.
   ///
   /// {@macro paginated_endpoint_streaming_parameters}
-  Stream<ThreadMember> streamThreadMembers({bool? withMembers, Snowflake? after, Snowflake? before, int? pageSize}) =>
-      manager.streamThreadMembers(id, withMembers: withMembers, after: after, before: before, pageSize: pageSize);
+  Stream<ThreadMember> streamThreadMembers(
+          {bool? withMembers,
+          Snowflake? after,
+          Snowflake? before,
+          int? pageSize}) =>
+      manager.streamThreadMembers(id,
+          withMembers: withMembers,
+          after: after,
+          before: before,
+          pageSize: pageSize);
 
   /// Create a builder with the properties of this thread
-  ThreadBuilder toBuilder() => ThreadBuilder(name: name, type: type, autoArchiveDuration: autoArchiveDuration, rateLimitPerUser: rateLimitPerUser);
+  ThreadBuilder toBuilder() => ThreadBuilder(
+        name: name,
+        type: type,
+        autoArchiveDuration: autoArchiveDuration,
+        rateLimitPerUser: rateLimitPerUser,
+      );
 }
 
 /// Extensions on [GuildCategory]s.
@@ -52,68 +75,90 @@ extension GuildCategoryExtensions on GuildCategory {
   }
 
   /// Return a list of channels in the client's cache that are in this category.
-  List<GuildChannel> get cachedChannels => guild.cachedChannels.where((element) => element.parentId == id).toList();
+  List<GuildChannel> get cachedChannels =>
+      guild.cachedChannels.where((element) => element.parentId == id).toList();
 
   /// Create a builder with the properties of this category
   GuildCategoryBuilder toBuilder() => GuildCategoryBuilder(
-      name: name,
-      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-      position: position);
+        name: name,
+        permissionOverwrites: permissionOverwrites
+            .map((e) => PermissionOverwriteBuilder(
+                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+            .toList(),
+        position: position,
+      );
 }
 
 /// Extensions on [GuildTextChannel]s.
 extension GuildTextChannelExtensions on GuildTextChannel {
   /// Create a builder with the properties of this channel
   GuildTextChannelBuilder toBuilder() => GuildTextChannelBuilder(
-      name: name,
-      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-      position: position,
-      defaultAutoArchiveDuration: defaultAutoArchiveDuration,
-      isNsfw: isNsfw,
-      parentId: parentId,
-      rateLimitPerUser: rateLimitPerUser,
-      topic: topic);
+        name: name,
+        permissionOverwrites: permissionOverwrites
+            .map((e) => PermissionOverwriteBuilder(
+                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+            .toList(),
+        position: position,
+        defaultAutoArchiveDuration: defaultAutoArchiveDuration,
+        isNsfw: isNsfw,
+        parentId: parentId,
+        rateLimitPerUser: rateLimitPerUser,
+        topic: topic,
+      );
 }
 
 /// Extensions on [GuildVoiceChannel]s.
 extension GuildVoiceChannelExtensions on GuildVoiceChannel {
   /// Create a builder with the properties of this channel
   GuildVoiceChannelBuilder toBuilder() => GuildVoiceChannelBuilder(
-      name: name,
-      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-      position: position,
-      isNsfw: isNsfw,
-      parentId: parentId,
-      bitRate: bitrate,
-      rtcRegion: rtcRegion,
-      userLimit: userLimit,
-      videoQualityMode: videoQualityMode);
+        name: name,
+        permissionOverwrites: permissionOverwrites
+            .map((e) => PermissionOverwriteBuilder(
+                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+            .toList(),
+        position: position,
+        isNsfw: isNsfw,
+        parentId: parentId,
+        bitRate: bitrate,
+        rtcRegion: rtcRegion,
+        userLimit: userLimit,
+        videoQualityMode: videoQualityMode,
+      );
 }
 
 /// Extensions on [GuildAnnouncementChannel]s.
 extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
   /// Create a builder with the properties of this channel
-  GuildAnnouncementChannelBuilder toBuilder() => GuildAnnouncementChannelBuilder(
-      name: name,
-      defaultAutoArchiveDuration: defaultAutoArchiveDuration,
-      isNsfw: isNsfw,
-      parentId: parentId,
-      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-      position: position,
-      topic: topic);
+  GuildAnnouncementChannelBuilder toBuilder() =>
+      GuildAnnouncementChannelBuilder(
+        name: name,
+        defaultAutoArchiveDuration: defaultAutoArchiveDuration,
+        isNsfw: isNsfw,
+        parentId: parentId,
+        permissionOverwrites: permissionOverwrites
+            .map((e) => PermissionOverwriteBuilder(
+                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+            .toList(),
+        position: position,
+        topic: topic,
+      );
 }
 
 /// Extensions on [GuildStageChannel]s.
 extension GuildStageChannelExtensions on GuildStageChannel {
   /// Create a builder with the properties of this channel
   GuildStageChannelBuilder toBuilder() => GuildStageChannelBuilder(
-      name: name,
-      bitRate: bitrate,
-      isNsfw: isNsfw,
-      parentId: parentId,
-      permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
-      position: position,
-      rtcRegion: rtcRegion,
-      userLimit: userLimit,
-      videoQualityMode: videoQualityMode);
+        name: name,
+        bitRate: bitrate,
+        isNsfw: isNsfw,
+        parentId: parentId,
+        permissionOverwrites: permissionOverwrites
+            .map((e) => PermissionOverwriteBuilder(
+                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
+            .toList(),
+        position: position,
+        rtcRegion: rtcRegion,
+        userLimit: userLimit,
+        videoQualityMode: videoQualityMode,
+      );
 }

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -13,8 +13,7 @@ extension PartialChannelExtensions on PartialChannel {
 /// Extensions on [Channel]s.
 extension ChannelExtensions on Channel {
   /// A URL clients can visit to navigate to this channel.
-  Uri get url => Uri.https(manager.client.apiOptions.host,
-      '/channels/${this is GuildChannel ? '${(this as GuildChannel).guildId}' : '@me'}/$id');
+  Uri get url => Uri.https(manager.client.apiOptions.host, '/channels/${this is GuildChannel ? '${(this as GuildChannel).guildId}' : '@me'}/$id');
 }
 
 /// Extensions on [GuildChannel]s.
@@ -22,22 +21,14 @@ extension GuildChannelExtensions on GuildChannel {
   /// Compute [member]'s permissions in this channel.
   ///
   /// {@macro compute_permissions_detail}
-  Future<Permissions> computePermissionsFor(PartialMember member) async =>
-      await computePermissions(this, await member.get());
+  Future<Permissions> computePermissionsFor(PartialMember member) async => await computePermissions(this, await member.get());
 
   /// Create a builder with the properties of this channel
   GuildChannelBuilder toBuilder() => GuildChannelBuilder(
         name: name,
         type: type,
         position: position,
-        permissionOverwrites: permissionOverwrites
-            .map((e) => PermissionOverwriteBuilder(
-                  id: e.id,
-                  type: e.type,
-                  allow: e.allow,
-                  deny: e.deny,
-                ))
-            .toList(),
+        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
       );
 }
 
@@ -46,32 +37,17 @@ extension ThreadExtensions on Thread {
   /// Same as [listThreadMembers], but has no limit on the number of members returned.
   ///
   /// {@macro paginated_endpoint_streaming_parameters}
-  Stream<ThreadMember> streamThreadMembers(
-          {bool? withMembers,
-          Snowflake? after,
-          Snowflake? before,
-          int? pageSize}) =>
-      manager.streamThreadMembers(id,
-          withMembers: withMembers,
-          after: after,
-          before: before,
-          pageSize: pageSize);
+  Stream<ThreadMember> streamThreadMembers({bool? withMembers, Snowflake? after, Snowflake? before, int? pageSize}) =>
+      manager.streamThreadMembers(id, withMembers: withMembers, after: after, before: before, pageSize: pageSize);
 
   /// Create a builder with the properties of this thread.
-  ThreadBuilder toBuilder() {
-    // Check for PrivateThread to pass invitable to the builder
-    bool? invitable;
-    if (this is PrivateThread) {
-      invitable = (this as PrivateThread).isInvitable;
-    }
-    return ThreadBuilder(
-      name: name,
-      type: type,
-      autoArchiveDuration: autoArchiveDuration,
-      invitable: invitable,
-      rateLimitPerUser: rateLimitPerUser,
-    );
-  }
+  ThreadBuilder toBuilder() => ThreadBuilder(
+        name: name,
+        type: type,
+        autoArchiveDuration: autoArchiveDuration,
+        invitable: this is PrivateThread ? (this as PrivateThread).isInvitable : null,
+        rateLimitPerUser: rateLimitPerUser,
+      );
 }
 
 /// Extensions on [GuildCategory]s.
@@ -84,16 +60,12 @@ extension GuildCategoryExtensions on GuildCategory {
   }
 
   /// Return a list of channels in the client's cache that are in this category.
-  List<GuildChannel> get cachedChannels =>
-      guild.cachedChannels.where((element) => element.parentId == id).toList();
+  List<GuildChannel> get cachedChannels => guild.cachedChannels.where((element) => element.parentId == id).toList();
 
   /// Create a builder with the properties of this category.
   GuildCategoryBuilder toBuilder() => GuildCategoryBuilder(
         name: name,
-        permissionOverwrites: permissionOverwrites
-            .map((e) => PermissionOverwriteBuilder(
-                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-            .toList(),
+        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
         position: position,
       );
 }
@@ -103,10 +75,7 @@ extension GuildTextChannelExtensions on GuildTextChannel {
   /// Create a builder with the properties of this channel.
   GuildTextChannelBuilder toBuilder() => GuildTextChannelBuilder(
         name: name,
-        permissionOverwrites: permissionOverwrites
-            .map((e) => PermissionOverwriteBuilder(
-                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-            .toList(),
+        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
         position: position,
         defaultAutoArchiveDuration: defaultAutoArchiveDuration,
         isNsfw: isNsfw,
@@ -121,10 +90,7 @@ extension GuildVoiceChannelExtensions on GuildVoiceChannel {
   /// Create a builder with the properties of this channel.
   GuildVoiceChannelBuilder toBuilder() => GuildVoiceChannelBuilder(
         name: name,
-        permissionOverwrites: permissionOverwrites
-            .map((e) => PermissionOverwriteBuilder(
-                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-            .toList(),
+        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
         position: position,
         isNsfw: isNsfw,
         parentId: parentId,
@@ -138,16 +104,12 @@ extension GuildVoiceChannelExtensions on GuildVoiceChannel {
 /// Extensions on [GuildAnnouncementChannel]s.
 extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
   /// Create a builder with the properties of this channel.
-  GuildAnnouncementChannelBuilder toBuilder() =>
-      GuildAnnouncementChannelBuilder(
+  GuildAnnouncementChannelBuilder toBuilder() => GuildAnnouncementChannelBuilder(
         name: name,
         defaultAutoArchiveDuration: defaultAutoArchiveDuration,
         isNsfw: isNsfw,
         parentId: parentId,
-        permissionOverwrites: permissionOverwrites
-            .map((e) => PermissionOverwriteBuilder(
-                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-            .toList(),
+        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
         position: position,
         topic: topic,
       );
@@ -161,10 +123,7 @@ extension GuildStageChannelExtensions on GuildStageChannel {
         bitRate: bitrate,
         isNsfw: isNsfw,
         parentId: parentId,
-        permissionOverwrites: permissionOverwrites
-            .map((e) => PermissionOverwriteBuilder(
-                id: e.id, type: e.type, allow: e.allow, deny: e.deny))
-            .toList(),
+        permissionOverwrites: permissionOverwrites.map((e) => PermissionOverwriteBuilder(id: e.id, type: e.type, allow: e.allow, deny: e.deny)).toList(),
         position: position,
         rtcRegion: rtcRegion,
         userLimit: userLimit,

--- a/lib/src/extensions/channel.dart
+++ b/lib/src/extensions/channel.dart
@@ -103,7 +103,8 @@ extension GuildAnnouncementChannelExtensions on GuildAnnouncementChannel {
       topic: topic);
 }
 
-extension Test on GuildStageChannel {
+/// Extensions on [GuildStageChannel]s.
+extension GuildStageChannelExtensions on GuildStageChannel {
   /// Create a builder with the properties of this channel
   GuildStageChannelBuilder toBuilder() => GuildStageChannelBuilder(
       name: name,


### PR DESCRIPTION
# Description

I added the .toBuilder() method to GuildChannel. With this you can copy a channel or use an existing channel as a template for a new one.

## Connected issues & potential other potential problems

Fixes #38 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
