### PR TITLE
feat: Add support for sanitizing slash commands mentions

### DIFF
--- a/lib/src/utils/sanitizer.dart
+++ b/lib/src/utils/sanitizer.dart
@@ -24,7 +24,6 @@ const _baseCommandNamePattern = r"[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]+";
 final commandMentionRegex = RegExp(
   '<\\/(?<commandName>(?:$_baseCommandNamePattern(?:\\s$_baseCommandNamePattern){0,2})):(\\d{17,19})>',
   unicode: true,
-  multiLine: true,
 );
 
 /// A type of target [sanitizeContent] can operate on.

--- a/lib/src/utils/sanitizer.dart
+++ b/lib/src/utils/sanitizer.dart
@@ -118,13 +118,12 @@ Future<String> sanitizeContent(
         SanitizerTarget.users || SanitizerTarget.roles => '@',
         SanitizerTarget.everyone => '@$_whitespaceCharacter',
         SanitizerTarget.channels => '#',
-        SanitizerTarget.emojis => '',
-        SanitizerTarget.commands => '</',
+        SanitizerTarget.emojis => ':',
+        SanitizerTarget.commands => '/',
       };
 
   String suffix(SanitizerTarget target) => switch (target) {
         SanitizerTarget.emojis => ':',
-        SanitizerTarget.commands => '>',
         _ => '',
       };
 

--- a/test/unit/sanitizer_test.dart
+++ b/test/unit/sanitizer_test.dart
@@ -5,10 +5,10 @@ import 'package:test/test.dart';
 
 const _whitespaceCharacter = "‎";
 
-final sampleContent = '<@1234> test <@!2345> test2 <@&3456> test3 <#4567> test4 <a:test_emoji:5678> test5 <:test_emoji:6789>';
-final removed = ' test  test2  test3  test4  test5 ';
+final sampleContent = '<@1234> test <@!2345> test2 <@&3456> test3 <#4567> test4 <a:test_emoji:5678> test5 <:test_emoji:6789> test6 </test command:123456789123456789>';
+final removed = ' test  test2  test3  test4  test5  test6 ';
 final sanitized =
-    '<@${_whitespaceCharacter}1234> test <@${_whitespaceCharacter}2345> test2 <@&${_whitespaceCharacter}3456> test3 <#${_whitespaceCharacter}4567> test4 <${_whitespaceCharacter}a:test_emoji:5678> test5 <$_whitespaceCharacter:test_emoji:6789>';
+    '<@${_whitespaceCharacter}1234> test <@${_whitespaceCharacter}2345> test2 <@&${_whitespaceCharacter}3456> test3 <#${_whitespaceCharacter}4567> test4 <${_whitespaceCharacter}a\\:test_emoji\\:5678> test5 <$_whitespaceCharacter\\:test_emoji\\:6789> test6 </${_whitespaceCharacter}test command:123456789123456789>';
 
 class MockNyxxRest with Mock implements NyxxRest {}
 


### PR DESCRIPTION
# Description
This also fixes an issue with emojis sanitization, since `<:hi:1234>` would be interpreted as `<literalemojihi:1234>` by discord


## Connected issues & potential other potential problems

If changes in PR are connected to other issues or are affecting code in other parts of framework
(e.g. in main package or any other subpackage) make sure to link issue/PR and describe said problem

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [ ] Ran `dart analyze` or `make analyze` and fixed all issues
- [ ] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
