### PR TITLE
Add utilities for fetching lists of entities

### DIFF
--- a/lib/nyxx_extensions.dart
+++ b/lib/nyxx_extensions.dart
@@ -30,3 +30,4 @@ export 'src/extensions/role.dart';
 export 'src/extensions/scheduled_event.dart';
 export 'src/extensions/snowflake_entity.dart';
 export 'src/extensions/user.dart';
+export 'src/extensions/list.dart';

--- a/lib/src/extensions/list.dart
+++ b/lib/src/extensions/list.dart
@@ -1,0 +1,11 @@
+import 'package:nyxx/nyxx.dart';
+
+/// Extensions for fetching lists of [SnowflakeEntity]s.
+extension PartialList<T extends SnowflakeEntity<T>>
+    on List<SnowflakeEntity<T>> {
+  /// Get all the entities in this list using the cached entity if possible.
+  Future<List<T>> get() => Future.wait(map((entity) => entity.get()));
+
+  /// Fetch all the entities in this list.
+  Future<List<T>> fetch() => Future.wait(map((entity) => entity.fetch()));
+}

--- a/lib/src/extensions/list.dart
+++ b/lib/src/extensions/list.dart
@@ -1,8 +1,7 @@
 import 'package:nyxx/nyxx.dart';
 
 /// Extensions for fetching lists of [SnowflakeEntity]s.
-extension PartialList<T extends SnowflakeEntity<T>>
-    on List<SnowflakeEntity<T>> {
+extension PartialList<T extends SnowflakeEntity<T>> on List<SnowflakeEntity<T>> {
   /// Get all the entities in this list using the cached entity if possible.
   Future<List<T>> get() => Future.wait(map((entity) => entity.get()));
 

--- a/test/unit/sanitizer_test.dart
+++ b/test/unit/sanitizer_test.dart
@@ -5,7 +5,8 @@ import 'package:test/test.dart';
 
 const _whitespaceCharacter = "‎";
 
-final sampleContent = '<@1234> test <@!2345> test2 <@&3456> test3 <#4567> test4 <a:test_emoji:5678> test5 <:test_emoji:6789> test6 </test command:123456789123456789>';
+final sampleContent =
+    '<@1234> test <@!2345> test2 <@&3456> test3 <#4567> test4 <a:test_emoji:5678> test5 <:test_emoji:6789> test6 </test command:123456789123456789>';
 final removed = ' test  test2  test3  test4  test5  test6 ';
 final sanitized =
     '<@${_whitespaceCharacter}1234> test <@${_whitespaceCharacter}2345> test2 <@&${_whitespaceCharacter}3456> test3 <#${_whitespaceCharacter}4567> test4 <${_whitespaceCharacter}a\\:test_emoji\\:5678> test5 <$_whitespaceCharacter\\:test_emoji\\:6789> test6 </${_whitespaceCharacter}test command:123456789123456789>';


### PR DESCRIPTION
# Description

As the title says. Allows for code such as the following:
```dart
// Before
final roles = await Future.wait(member.roles.map((r) => r.get()));

// After
final roles = await member.roles.get();
```

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
